### PR TITLE
Fix clap deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "^3.0", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 dirs = "^4"
 notify-rust = "^4.5"
 serde = "^1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -461,11 +461,11 @@ mod value_parsing_tests {
 }
 
 mod args {
-    use clap::{AppSettings, Parser, ValueHint};
+    use clap::{Parser, ValueHint};
 
     // Runs a command and sends a notification upon completion
     #[derive(Parser, Debug)]
-    #[clap(author, version, about, long_about = None, setting = AppSettings::TrailingVarArg)]
+    #[clap(author, version, about, long_about = None, trailing_var_arg = true)]
     pub struct Args {
         #[clap(
             short,


### PR DESCRIPTION
clap-rs released a new version on 2022-02-16 that deprecated the use of
AppSettings::TrailingVarArg. This change uses the trailing_var_arg
function on the App directly.

Closes #2.